### PR TITLE
Update swapi URL in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ const port = process.env.PORT || 8080;
 const base = process.env.BASE || "/";
 const ABORT_DELAY = 10000;
 const GRAPHQL_URL = new URL(
-  "https://swapi-graphql.netlify.app/.netlify/functions/index",
+  "https://swapi-graphql.netlify.app/graphql",
 );
 
 // Cached production assets


### PR DESCRIPTION
The URL changed, and the express proxy implementation does not handle the redirect, this manually switches the URL and now the example boots up

Thanks for the post and example code!